### PR TITLE
Change example link and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ```
 Dither it! is a web application for dithering images. It is built with Vue, using NuxtJS. Visit it at [ditherit.com](https://ditherit.com).
 
-![Dither example](https://ditherit.com/_nuxt/img/earth-dither.993faef.gif)
+![Dither example](https://ditherit.com/_nuxt/img/earth-dither.0f5dea9.gif)
 
 You can run it locally by cloning the repo and running the following:
 
@@ -29,6 +29,9 @@ $ npm run test
 # generate static project
 $ npm run generate
 ```
+
+In some cases (as of Node.js v17) it is necessary to run the command `export NODE_OPTIONS=--openssl-legacy-provider` for handling key size on OpenSSL v3.
+After that `$ npm run dev` works.
 
 For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).
 


### PR DESCRIPTION
- The example gif in the readme is no longer available (404).
- Add additional command if using Node.js v18.x see [Stackoverflow](https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported)